### PR TITLE
Fixed args for start() call on restart().

### DIFF
--- a/initd.py
+++ b/initd.py
@@ -106,7 +106,7 @@ class Initd(object):
         except IOError as ioe:
             if ioe.errno != errno.ENOENT:
                 raise
-            sys.stdout('Stopped.\n')
+            sys.stdout.write('Stopped.\n')
             return
         sys.stdout.write('Stopping.')
         sys.stdout.flush()


### PR DESCRIPTION
When trying to restart a daemon that's already stopped, the start call raises the following exception:

Traceback (most recent call last):
  File "manage.py", line 14, in <module>
    execute_manager(settings)
  File "/usr/lib/python2.6/site-packages/django/core/management/**init**.py", line 459, in execute_manager
    utility.execute()
  File "/usr/lib/python2.6/site-packages/django/core/management/**init**.py", line 382, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/lib/python2.6/site-packages/django/core/management/base.py", line 196, in run_from_argv
    self.execute(_args, *_options.**dict**)
  File "/usr/lib/python2.6/site-packages/django/core/management/base.py", line 232, in execute
    output = self.handle(_args, *_options)
  File "/usr/lib/python2.6/site-packages/django/core/management/base.py", line 371, in handle
    return self.handle_noargs(**options)
  File "/usr/lib/python2.6/site-packages/django_initd-0.0.1-py2.6.egg/daemon_command.py", line 64, in handle_noargs
    daemon.execute(action, run=self.loop_callback, exit=self.exit_callback)
  File "/usr/lib/python2.6/site-packages/django_initd-0.0.1-py2.6.egg/initd.py", line 131, in execute
    cmd(run, exit)
  File "/usr/lib/python2.6/site-packages/django_initd-0.0.1-py2.6.egg/initd.py", line 126, in restart
    self.start(run, self.pid_file, self.log_file)
TypeError: start() takes at most 3 arguments (4 given)

Which is fixed by this commit. Thanks for such a helpful package :)
